### PR TITLE
Add Matomo snippet to each webpage

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -32,6 +32,8 @@ limitations under the License.
 
     <!-- Custom style -->
     <link href="/assets/css/style.css" rel="stylesheet">
+
+    {{ partial "matomo.html" . }}
 </head>
 <body class="light-grey">
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,6 +32,8 @@ limitations under the License.
 
     <!-- Custom style -->
     <link href="/assets/css/style.css" rel="stylesheet">
+
+    {{ partial "matomo.html" . }}
 </head>
 <body class="light-grey">
 

--- a/layouts/celix-doc/baseof.html
+++ b/layouts/celix-doc/baseof.html
@@ -32,6 +32,8 @@ limitations under the License.
 
     <!-- Custom style -->
     <link href="/assets/css/style.css" rel="stylesheet">
+
+    {{ partial "matomo.html" . }}
 </head>
 <body class="light-grey">
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,6 +35,8 @@ limitations under the License.
 
     <!-- Font awesome icon set -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+
+    {{ partial "matomo.html" . }}
 </head>
 <body>
 

--- a/layouts/partials/matomo.html
+++ b/layouts/partials/matomo.html
@@ -1,0 +1,17 @@
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* We explicitly disable cookie tracking to avoid privacy issues */
+  _paq.push(['disableCookies']);
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://analytics.apache.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '9']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->


### PR DESCRIPTION
Matomo is a privacy friendly tracking solution hosted on ASF hardware with page statistics publicly available via https://analytics.apache.org

Multiple Apache projects are already using this and I think it will be useful for Celix as well to gain insights about the number of visitors and which pages a visitor is interested in.

If this is working I'll post this to the dev@celix list as well for others to be aware.