### PR TITLE
Do not require approvals on pull requests

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,5 +44,6 @@ github:
   protected_branches:
     asf-site: {}
     master:
-      required_pull_request_reviews: {}
+      required_pull_request_reviews:
+        required_approving_review_count: 0
 

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,5 +45,7 @@ github:
     asf-site: {}
     master:
       required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
         required_approving_review_count: 0
 


### PR DESCRIPTION
See https://github.com/apache/celix/pull/398#pullrequestreview-880993280 . Celix is a small project which doesn't need this setting yet