### PR TITLE
Add link to main site on how to verify a release

### DIFF
--- a/source/download.md
+++ b/source/download.md
@@ -43,3 +43,6 @@ You may also consult the [complete list of mirrors](https://www.apache.org/mirro
 [ [PGP](https://downloads.apache.org/celix/celix-{{< param "latestVersion" >}}/celix-{{< param "latestVersion" >}}.tar.gz.asc) ]
 [ [SHA512](https://downloads.apache.org/celix/celix-{{< param "latestVersion" >}}/celix-{{< param "latestVersion" >}}.tar.gz.sha512) ]
 
+### Verify the downloaded release
+
+Following the steps described <a href="https://www.apache.org/dyn/closer.cgi#verify">here</a> if you want to verify the integrity and provenance of the software.


### PR DESCRIPTION
To verify the new `2.4.0` release candidate I had to look around on which steps to execute again.

I think it would be good for us, but also for our users if we add a link to the Apache site on which steps to execute.