### PR TITLE
Remove internal css to external file from baseof.html file

### DIFF
--- a/layouts/celix-doc/baseof.html
+++ b/layouts/celix-doc/baseof.html
@@ -32,22 +32,7 @@ limitations under the License.
 
     <!-- Custom style -->
     <link href="/assets/css/style.css" rel="stylesheet">
-
-    <style>
-        /* TODO: Ideally the styling below will be moved to the style.css. That doesn't seem to work and needs investigating */
-        /* Redefine .img-fluid (bootstrap element) for all images, to allow defining images in markdown which do no 'escape' their card */
-        .card-body img {
-            max-width: 100%;
-            width: 100%;
-            height: auto;
-        }
-
-        /* Allow defining captions for images (will be italic and underlined) */
-        .card-body img + em {
-            text-decoration: underline;
-        }
-    </style>
-
+    
     {{ partial "matomo.html" . }}
 </head>
 <body class="light-grey">

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -153,6 +153,16 @@ a.edit-on-gh {
 .card {
   height: 100%;
 }
+.card-body img {
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+}
+
+/* Allow defining captions for images (will be italic and underlined) */
+.card-body img + em {
+  text-decoration: underline;
+}
 
 /*
  * Media Queries


### PR DESCRIPTION
PR Title: Moved Inline CSS to External style.css (Fixes #22)
Description:
Refactored inline styles into style.css to improve maintainability, reusability, and performance. This enhances readability, enables caching, and aligns with best practices. Verified UI consistency with no styling issues. 
